### PR TITLE
31 fix named color changed by new nav bar update

### DIFF
--- a/kuromalun-front/src/app/circleCreateEdit/page.tsx
+++ b/kuromalun-front/src/app/circleCreateEdit/page.tsx
@@ -13,13 +13,13 @@ const page = () => {
         <CircleImageTop src="/haikei.png" text="watnow"/>
       </div>
       {/* 内容 */}
-      <div className='bg-mainColor md:w-1/2 m-4 flex-col overflow-y-auto'>
+      <div className='bg-backgroundColor md:w-1/2 m-4 flex-col overflow-y-auto'>
         <CircleInputText icon={IoClipboardSharp} width={6} height={6} text='活動内容' exampleText='イベントたくさん！' />
         <CircleInputText icon={IoLocationSharp} width={6} height={6} text='活動場所' exampleText='OIC屋上' />
         <CircleInputText icon={IoTime} width={6} height={6} text='活動時間' exampleText='放課後' />
         <CircleInputText icon={IoPeopleSharp} width={6} height={6} text='人数' exampleText='30人前後' />
         <CircleDetailTextItem icon={IoLink} width={6} height={6} text='リンク'/>
-        <div className='p-2 my-3 border-zinc-600 border rounded-xl'>
+        <div className='p-2 my-3 border rounded-xl'>
           <LinkInItem text='タイトル' exampleText='HPはこちら' />
           <LinkInItem text='URL' exampleText='http://watnow.com' />
         </div>

--- a/kuromalun-front/src/app/circleDetail/page.tsx
+++ b/kuromalun-front/src/app/circleDetail/page.tsx
@@ -13,7 +13,7 @@ const page = () => {
         <CircleImageTop src="/haikei.png" text="watnow"/>
       </div>
       {/* 内容 */}
-      <div className='bg-mainColor md:w-1/2 m-4 flex-col overflow-y-auto'>
+      <div className='bg-backgroundColor md:w-1/2 m-4 flex-col overflow-y-auto'>
         <CircleDetailText icon={IoClipboardSharp} width={6} height={6} text='活動内容' exampleText='イベントたくさんイベントたくさんイベントたくさんイベントたくさんイベントたくさんイベントたくさんイベントたくさんイベントたくさんイベントたくさんイベントたくさんイベントたくさんイベントたくさんイベントたくさんイベントたくさんイベントたくさんイベントたくさんイベントたくさんイベントたくさん！' />
         <CircleDetailText icon={IoLocationSharp} width={6} height={6} text='活動場所' exampleText='OIC屋上' />
         <CircleDetailText icon={IoTime} width={6} height={6} text='活動時間' exampleText='放課後' />

--- a/kuromalun-front/src/components/CircleDetailText.tsx
+++ b/kuromalun-front/src/components/CircleDetailText.tsx
@@ -15,7 +15,7 @@ const CircleDetailText = (props: CircleDetailTextProps) => {
   return (
     <div className='mb-4'>
       <CircleDetailTextItem icon={icon} width={width} height={height} text={text}/>
-      <p className='w-full md:h-90vh border-backgroundColor border rounded-xl p-2 mt-2'>
+      <p className='w-full md:h-90vh border-mainColor border rounded-xl p-2 mt-2'>
         {exampleText}
       </p>
     </div>

--- a/kuromalun-front/src/components/CircleInputText.tsx
+++ b/kuromalun-front/src/components/CircleInputText.tsx
@@ -17,7 +17,7 @@ const CircleInputText = (props: CircleInputTextProps) => {
       <CircleDetailTextItem icon={icon} width={width} height={height} text={text}/>
       <textarea 
         placeholder={exampleText}
-        className='w-full md:h-90vh border-backgroundColor border rounded-xl p-2 mt-2'
+        className='w-full md:h-90vh border-mainColor border rounded-xl p-2 mt-2'
       />
     </div>
   )

--- a/kuromalun-front/src/components/Navigation.tsx
+++ b/kuromalun-front/src/components/Navigation.tsx
@@ -12,7 +12,7 @@ const Navigation: React.FC = () => {
 
   return (
     <div>
-      <nav className='fixed z-50 bg-mainColor w-full flex justify-between items-center'>
+      <nav className='fixed z-50 bg-backgroundColor w-full flex justify-between items-center'>
         <ul className='items-center flex'>
           <li className='justify-center'>
             <a href="/" className={getLinkClasses('/')}>ホーム</a>

--- a/kuromalun-front/tailwind.config.ts
+++ b/kuromalun-front/tailwind.config.ts
@@ -15,8 +15,8 @@ const config: Config = {
       },
     },
     colors: {
-      backgroundColor: "#000000",
-      mainColor: "#ffffff",
+      backgroundColor: "#ffffff",
+      mainColor: "#000000",
       color: "#9F9F9F",
       emphasisColor: "#FEB06A",
     },


### PR DESCRIPTION
背景色・ボーダー色の指定と、色名の設定を修正しました
<img width="299" alt="image" src="https://github.com/hiromuota166/kuromalun/assets/20058094/7d255635-cd1b-4711-ba3a-9b813ebda791">

ボーダー色がChakraの影響で外れてる箇所があるようですが急ぎなので[別issue](https://github.com/hiromuota166/kuromalun/issues/32)にしてます
<img width="296" alt="image" src="https://github.com/hiromuota166/kuromalun/assets/20058094/3bf77843-26e3-4a99-8b9b-4306c73c36ad">
